### PR TITLE
Add ARC64 support

### DIFF
--- a/config/arch/arc.in
+++ b/config/arch/arc.in
@@ -2,15 +2,20 @@
 
 ## no-package
 ## select ARCH_SUPPORTS_32
+## select ARCH_SUPPORTS_64
 ## select ARCH_DEFAULT_32
 ## select ARCH_SUPPORTS_BOTH_MMU
 ## select ARCH_DEFAULT_HAS_MMU
-## select ARCH_SUPPORTS_EITHER_ENDIAN
+## select ARCH_SUPPORTS_EITHER_ENDIAN if ARCH_32
 ## select ARCH_DEFAULT_LE
 ## select ARCH_SUPPORTS_WITH_CPU
 ## select GCC_REQUIRE_7_or_later
 ## select BINUTILS_REQUIRE_2_30_or_later
 ## select LINUX_REQUIRE_4_8_or_later if KERNEL_LINUX
+
+#  Fixme: when ARC64 gets into upstream autotools package
+#         for now we need to use config.sub bundled in CT-NG
+## select TARGET_SKIP_CONFIG_SUB
 ##
 ## help The Synopsys DesignWare ARC architecture, see more info here:
 ## help     https://www.synopsys.com/designware-ip/processor-solutions/arc-processors.html

--- a/scripts/build/arch/arc.sh
+++ b/scripts/build/arch/arc.sh
@@ -2,8 +2,19 @@
 
 CT_DoArchTupleValues()
 {
-    # The architecture part of the tuple:
-    CT_TARGET_ARCH="${CT_ARCH}${CT_ARCH_SUFFIX:-${target_endian_eb}}"
+    case "${CT_ARCH_BITNESS}" in
+        32)
+            CT_TARGET_ARCH="${CT_ARCH}${CT_ARCH_SUFFIX:-${target_endian_eb}}"
+            ;;
+        64)
+            # arc64 is little-endian only for now
+            # and thus "-mlittle-endian" option in GCC is obsolete for arc64
+            CT_TARGET_ARCH="arc64${CT_ARCH_SUFFIX}"
+            CT_ARCH_ENDIAN_CFLAG=""
+            # The same goes to the linker - we only build for little-endian.
+            CT_ARCH_ENDIAN_LDFLAG=""
+            ;;
+    esac
 }
 
 CT_DoArchUClibcConfig()

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -8,11 +8,6 @@ do_debug_gdb_get()
 do_debug_gdb_extract()
 {
     CT_ExtractPatch GDB
-
-    # Workaround for bad versions, where the configure
-    # script for gdbserver is not executable...
-    # Bah, GNU folks strike again... :-(
-    chmod a+x "${CT_SRC_DIR}/gdb/gdb/gdbserver/configure"
 }
 
 do_debug_gdb_build_cross()

--- a/scripts/config.sub
+++ b/scripts/config.sub
@@ -1165,7 +1165,7 @@ case $cpu-$vendor in
 			| alphapca5[67] | alpha64pca5[67] \
 			| am33_2.0 \
 			| amdgcn \
-			| arc | arceb \
+			| arc | arceb | arc64 \
 			| arm | arm[lb]e | arme[lb] | armv* \
 			| avr | avr32 \
 			| asmjs \


### PR DESCRIPTION
This adds ARC64 support needed to build Zephyr's SDK for the aforementioned architecture.

Note the patch for GDB has nothing to do with ARC64 stuff whatsoever other than GDB for ARC64 is based on upstream master and so we have to take care of that `gdbserver` promotion to top-level (see https://github.com/crosstool-ng/crosstool-ng/pull/1484 for more details).

As for ARC64 support itself that patch is not yet "upstreamable" to CT-NG as there's no upstream release of either GCC or Binutils with ARC64 support. Once corresponding support gets merged we'll add ARC64 support to upstream CT-NG.