### PR TITLE
Add CT_GDB_CROSS_STATIC_LIBSTDCXX configuration

### DIFF
--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -26,6 +26,15 @@ config GDB_CROSS_STATIC
       That way, you can share the cross-gdb without installing a toolchain
       on every machine that will be used to debug target programs.
 
+config GDB_CROSS_STATIC_LIBSTDCXX
+    bool
+    prompt "Link against static libstdc+++"
+    depends on !GDB_CROSS_STATIC
+    default y
+    help
+      Say 'y' if you do not want gdb to require libstdc++ and libgcc shared
+      libraries on the host.
+
 config GDB_CROSS_SIM
     bool
     prompt "Enable 'sim'"

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -258,6 +258,18 @@ do_gdb_backend()
                 ldflags+=" -static-libstdc++"
                 ;;
         esac
+
+        # Disable source-highlight when building with static libstdc++ because
+        # the source-highlight library is enabled by default, and GDB configure
+        # script complains when these two options are simultaneously enabled:
+        #
+        #   configure: error: source highlight is incompatible with
+        #   -static-libstdc++
+        #
+        # This is more of a temporary workaround than a permanent fix -- this
+        # should be reworked to resolve the conflicts in the Kconfig when the
+        # source-highlight support is directly added to crosstool-ng.
+        extra_config+=("--disable-source-highlight")
     fi
 
 

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -56,6 +56,7 @@ do_debug_gdb_build_cross()
         ldflags="${CT_LDFLAGS_FOR_HOST}" \
         prefix="${CT_PREFIX_DIR}" \
         static="${CT_GDB_CROSS_STATIC}" \
+        static_libstdcxx="${CT_GDB_CROSS_STATIC_LIBSTDCXX}" \
         --with-sysroot="${CT_SYSROOT_DIR}"          \
         "${cross_extra_config[@]}"
 
@@ -246,8 +247,17 @@ do_gdb_backend()
         ldflags+=" -static"
     fi
     if [ "${static_libstdcxx}" = "y" ]; then
-        ldflags+=" -static-libgcc"
-        ldflags+=" -static-libstdc++"
+        case "$CT_HOST" in
+            *darwin*)
+                # macOS builds with clang and provides a well known execution
+                # environment, so there is little point in static linking the
+                # C++ runtime library -- ignore this option for now.
+                ;;
+            *)
+                ldflags+=" -static-libgcc"
+                ldflags+=" -static-libstdc++"
+                ;;
+        esac
     fi
 
 


### PR DESCRIPTION
This commit adds a new configuration `CT_GDB_CROSS_STATIC_LIBSTDCXX`,
which enables static linking of libstdc++ and libgcc for the cross-gdb
running on the host.

This configuration is enabled by default because using shared "standard
libraries" can often cause compatibility problems when distributing
toolchain binaries and it is therefore highly desirable to always
static-link them.

Note that this behaviour aligns with other similar symbols such as
`CT_CC_GCC_STATIC_LIBSTDCXX` and `CT_GDB_NATIVE_STATIC_LIBSTDCXX`.

For macOS, GDB is built using the Clang compiler, which is the default
compiler for the macOS hosts, and `libstdc++` and `libgcc` are not
applicable for obvious reasons.

Since macOS provides a fairly well known and controlled execution
environment, there is little point in static linking the C++ runtime
library.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>