### PR TITLE
newlib-nano: Fix include path for CT_NEWLIB_NANO_INSTALL_IN_TARGET

### DIFF
--- a/scripts/build/companion_libs/350-newlib_nano.sh
+++ b/scripts/build/companion_libs/350-newlib_nano.sh
@@ -203,7 +203,7 @@ ENABLE_TARGET_OPTSPACE:target-optspace
 %rename cpp_unique_options  nano_cpp_unique_options
 
 *cpp_unique_options:
--isystem =/include/newlib-nano %(nano_cpp_unique_options)
+-isystem %:getenv(GCC_EXEC_PREFIX ../../${CT_TARGET}/include/newlib-nano) %(nano_cpp_unique_options)
 
 *nano_libc:
 -lc_nano


### PR DESCRIPTION
When `CT_NEWLIB_NANO_INSTALL_IN_TARGET=y`, the `nano.specs` file
emitted by the newlib-nano build script contains an invalid include
path, resulting in the full `newlib.h` being included instead of the
nano `newlib.h` by the application.

`=/include/newlib-nano` is not a valid path (`=` does not mean anything
and that string is taken as an include path as-is) and GCC ignores this
include path, resulting in application including the `newlib.h` from
`include/` which contains the newlib build configurations for the full
newlib.

This commit modifies the newlib-nano build script to emit a proper
newlib-nano include path relative to the `GCC_EXEC_PREFIX`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Upstream PR: https://github.com/crosstool-ng/crosstool-ng/pull/1721