### PR TITLE
gdb: Build additional Python scripting-capable variant

### DIFF
--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -58,6 +58,17 @@ config GDB_CROSS_PYTHON
       have been reports of problems when linking gdb to the static
       libpython.a. This should be fixed in gdb >=7.3. YMMV.
 
+config GDB_CROSS_PYTHON_VARIANT
+    bool
+    prompt "Build additional Python-capable gdb variant (gdb-py)"
+    depends on GDB_CROSS_PYTHON
+    help
+      Build an additional gdb variant (gdb-py) that supports Python scripting.
+
+      When this option is enabled, the default gdb variant (gdb) does not link
+      against libpython; instead, an additional Python-capable gdb variant
+      executable (gdb-py) that links against libpython is built.
+
 config GDB_CROSS_PYTHON_BINARY
     string "Python binary to use"
     depends on GDB_CROSS_PYTHON

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -10,100 +10,105 @@ do_debug_gdb_extract()
     CT_ExtractPatch GDB
 }
 
+do_debug_gdb_build_cross()
+{
+    local gcc_version p _p
+    local -a cross_extra_config
+
+    CT_DoStep INFO "Installing cross-gdb"
+    CT_mkdir_pushd "${CT_BUILD_DIR}/build-gdb-cross"
+
+    cross_extra_config=( "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}" )
+    if [ "${CT_GDB_CROSS_PYTHON}" = "y" ]; then
+        if [ -z "${CT_GDB_CROSS_PYTHON_BINARY}" ]; then
+            if [ "${CT_CANADIAN}" = "y" -o "${CT_CROSS_NATIVE}" = "y" ]; then
+                CT_Abort "For canadian build, Python wrapper runnable on the build machine must be provided. Set CT_GDB_CROSS_PYTHON_BINARY."
+            elif [ "${CT_CONFIGURE_has_python}" = "y" ]; then
+                cross_extra_config+=("--with-python=${python}")
+            else
+                CT_Abort "Python support requested in GDB, but Python not found. Set CT_GDB_CROSS_PYTHON_BINARY."
+            fi
+        else
+            cross_extra_config+=("--with-python=${CT_GDB_CROSS_PYTHON_BINARY}")
+        fi
+    else
+        cross_extra_config+=("--with-python=no")
+    fi
+
+    if [ "${CT_GDB_CROSS_SIM}" = "y" ]; then
+        cross_extra_config+=("--enable-sim")
+    else
+        cross_extra_config+=("--disable-sim")
+    fi
+
+    if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
+        # clang detects the line from gettext's _ macro as format string
+        # not being a string literal and produces a lot of warnings - which
+        # ct-ng's logger faithfully relays to user if this happens in the
+        # error() function. Suppress them.
+        cross_extra_config+=("--enable-build-warnings=,-Wno-format-nonliteral,-Wno-format-security")
+    fi
+
+    # Target libexpat resides in sysroot and does not have
+    # any dependencies, so just passing '-lexpat' to gcc is enough.
+    #
+    # By default gdb configure looks for expat in '$prefix/lib'
+    # directory. In our case '$prefix/lib' resolves to '/usr/lib'
+    # where libexpat for build platform lives, which is
+    # unacceptable for cross-compiling.
+    #
+    # To prevent this '--without-libexpat-prefix' flag must be passed.
+    # Thus configure falls back to '-lexpat', which is exactly what we want.
+    #
+    # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
+    # It conflicts with a static build: GDB's configure script will find the shared
+    # version of expat and will attempt to link that, despite the -static flag.
+    # The link will fail, and configure will abort with "expat missing or unusable"
+    # message.
+    extra_config+=("--with-expat")
+    extra_config+=("--without-libexpat-prefix")
+
+    do_gdb_backend \
+        buildtype=cross \
+        host="${CT_HOST}" \
+        cflags="${CT_CFLAGS_FOR_HOST}" \
+        ldflags="${CT_LDFLAGS_FOR_HOST}" \
+        prefix="${CT_PREFIX_DIR}" \
+        static="${CT_GDB_CROSS_STATIC}" \
+        static_libstdcxx="${CT_GDB_CROSS_STATIC_LIBSTDCXX}" \
+        --with-sysroot="${CT_SYSROOT_DIR}"          \
+        "${cross_extra_config[@]}"
+
+    if [ "${CT_BUILD_MANUALS}" = "y" ]; then
+        CT_DoLog EXTRA "Building and installing the cross-GDB manuals"
+        CT_DoExecLog ALL make ${CT_JOBSFLAGS} pdf html
+        CT_DoExecLog ALL make install-{pdf,html}-gdb
+    fi
+
+    CT_DoLog EXTRA "Installing '.gdbinit' template"
+    # See in scripts/build/internals.sh for why we do this
+    # TBD GCC 3.x and older not supported
+    if [ -f "${CT_SRC_DIR}/gcc/gcc/BASE-VER" ]; then
+        gcc_version=$(cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER")
+    else
+        gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
+                            "${CT_SRC_DIR}/gcc/gcc/version.c"   \
+                        )
+    fi
+    sed -r                                                  \
+            -e "s:@@PREFIX@@:${CT_PREFIX_DIR}:;"             \
+            -e "s:@@VERSION@@:${gcc_version}:;"              \
+            "${CT_LIB_DIR}/scripts/build/debug/gdbinit.in"   \
+            >"${CT_PREFIX_DIR}/share/gdb/gdbinit"
+
+    CT_Popd
+    CT_EndStep
+}
+
 do_debug_gdb_build()
 {
     if [ "${CT_GDB_CROSS}" = "y" ]; then
-        local gcc_version p _p
-        local -a cross_extra_config
-
-        CT_DoStep INFO "Installing cross-gdb"
-        CT_mkdir_pushd "${CT_BUILD_DIR}/build-gdb-cross"
-
-        cross_extra_config=( "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}" )
-        if [ "${CT_GDB_CROSS_PYTHON}" = "y" ]; then
-            if [ -z "${CT_GDB_CROSS_PYTHON_BINARY}" ]; then
-                if [ "${CT_CANADIAN}" = "y" -o "${CT_CROSS_NATIVE}" = "y" ]; then
-                    CT_Abort "For canadian build, Python wrapper runnable on the build machine must be provided. Set CT_GDB_CROSS_PYTHON_BINARY."
-                elif [ "${CT_CONFIGURE_has_python}" = "y" ]; then
-                    cross_extra_config+=("--with-python=${python}")
-                else
-                    CT_Abort "Python support requested in GDB, but Python not found. Set CT_GDB_CROSS_PYTHON_BINARY."
-                fi
-            else
-                cross_extra_config+=("--with-python=${CT_GDB_CROSS_PYTHON_BINARY}")
-            fi
-        else
-            cross_extra_config+=("--with-python=no")
-        fi
-
-        if [ "${CT_GDB_CROSS_SIM}" = "y" ]; then
-            cross_extra_config+=("--enable-sim")
-        else
-            cross_extra_config+=("--disable-sim")
-        fi
-
-        if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
-            # clang detects the line from gettext's _ macro as format string
-            # not being a string literal and produces a lot of warnings - which
-            # ct-ng's logger faithfully relays to user if this happens in the
-            # error() function. Suppress them.
-            cross_extra_config+=("--enable-build-warnings=,-Wno-format-nonliteral,-Wno-format-security")
-        fi
-
-        # Target libexpat resides in sysroot and does not have
-        # any dependencies, so just passing '-lexpat' to gcc is enough.
-        #
-        # By default gdb configure looks for expat in '$prefix/lib'
-        # directory. In our case '$prefix/lib' resolves to '/usr/lib'
-        # where libexpat for build platform lives, which is
-        # unacceptable for cross-compiling.
-        #
-        # To prevent this '--without-libexpat-prefix' flag must be passed.
-        # Thus configure falls back to '-lexpat', which is exactly what we want.
-        #
-        # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
-        # It conflicts with a static build: GDB's configure script will find the shared
-        # version of expat and will attempt to link that, despite the -static flag.
-        # The link will fail, and configure will abort with "expat missing or unusable"
-        # message.
-        extra_config+=("--with-expat")
-        extra_config+=("--without-libexpat-prefix")
-
-        do_gdb_backend \
-            buildtype=cross \
-            host="${CT_HOST}" \
-            cflags="${CT_CFLAGS_FOR_HOST}" \
-            ldflags="${CT_LDFLAGS_FOR_HOST}" \
-            prefix="${CT_PREFIX_DIR}" \
-            static="${CT_GDB_CROSS_STATIC}" \
-            static_libstdcxx="${CT_GDB_CROSS_STATIC_LIBSTDCXX}" \
-            --with-sysroot="${CT_SYSROOT_DIR}"          \
-            "${cross_extra_config[@]}"
-
-        if [ "${CT_BUILD_MANUALS}" = "y" ]; then
-            CT_DoLog EXTRA "Building and installing the cross-GDB manuals"
-            CT_DoExecLog ALL make ${CT_JOBSFLAGS} pdf html
-            CT_DoExecLog ALL make install-{pdf,html}-gdb
-        fi
-
-        CT_DoLog EXTRA "Installing '.gdbinit' template"
-        # See in scripts/build/internals.sh for why we do this
-        # TBD GCC 3.x and older not supported
-        if [ -f "${CT_SRC_DIR}/gcc/gcc/BASE-VER" ]; then
-            gcc_version=$(cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER")
-        else
-            gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
-                               "${CT_SRC_DIR}/gcc/gcc/version.c"   \
-                         )
-        fi
-        sed -r                                                  \
-               -e "s:@@PREFIX@@:${CT_PREFIX_DIR}:;"             \
-               -e "s:@@VERSION@@:${gcc_version}:;"              \
-               "${CT_LIB_DIR}/scripts/build/debug/gdbinit.in"   \
-               >"${CT_PREFIX_DIR}/share/gdb/gdbinit"
-
-        CT_Popd
-        CT_EndStep
+        do_debug_gdb_build_cross
     fi
 
     if [ "${CT_GDB_NATIVE}" = "y" ]; then


### PR DESCRIPTION
This commit adds an option to build an additional gdb variant (gdb-py)
that supports Python scripting.

When this option is enabled, the default gdb variant (gdb) does not
link against libpython; instead, an additional Python-capable gdb
variant executable (gdb-py) that links against libpython is built.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>