### PR TITLE
scripts: build: Discard more debug sections when stripping libraries

### DIFF
--- a/scripts/build/internals.sh
+++ b/scripts/build/internals.sh
@@ -162,7 +162,8 @@ strip_target_lib()
         --discard-locals
         -R .comment -R .note -R .debug_info -R .debug_aranges
         -R .debug_pubnames -R .debug_pubtypes -R .debug_abbrev -R .debug_line
-        -R .debug_str -R .debug_ranges -R .debug_loc
+        -R .debug_str -R .debug_ranges -R .debug_loc -R .debug_loclists
+        -R .debug_rnglists -R .debug_line_str
         "
 
     find "$1" -name "$2" | while read target_lib; do


### PR DESCRIPTION
This commit updates the build script to strip additional debug sections
added by the Binutils 2.38 when stripping the target libraries.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>