### PR TITLE
cross-gdb: Add LZMA and Guile scripting support configuration

### DIFF
--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -96,6 +96,16 @@ config GDB_CROSS_LZMA
       Note that crosstool-ng does not build liblzma for the host and you are
       responsible for providing this library on the build system.
 
+config GDB_CROSS_GUILE
+    bool
+    prompt "Build GDB with GNU Guile scripting support"
+    help
+      Build GDB with libguile, a library implementing the GNU Guile scripting
+      feature.
+
+      Note that crosstool-ng does not build libguile for the host and you are
+      responsible for providing this library on the build system.
+
 config GDB_CROSS_EXTRA_CONFIG_ARRAY
     string
     prompt "Cross-gdb extra config"

--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -85,6 +85,17 @@ config GDB_CROSS_PYTHON_BINARY
       help message in gdb's configure script for the --with-python option
       for further guidance.
 
+config GDB_CROSS_LZMA
+    bool
+    prompt "Build GDB with LZMA"
+    help
+      Build GDB with liblzma, a compression library supporting the LZMA
+      algorithm. LZMA is used by the GDB's "mini debuginfo" feature, which is
+      only useful on the platforms using the ELF object file format.
+
+      Note that crosstool-ng does not build liblzma for the host and you are
+      responsible for providing this library on the build system.
+
 config GDB_CROSS_EXTRA_CONFIG_ARRAY
     string
     prompt "Cross-gdb extra config"

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -65,6 +65,12 @@ do_debug_gdb_build_cross()
         cross_extra_config+=("--without-lzma")
     fi
 
+    if [ "${CT_GDB_CROSS_GUILE}" = "y" ]; then
+        cross_extra_config+=("--with-guile")
+    else
+        cross_extra_config+=("--without-guile")
+    fi
+
     if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
         # clang detects the line from gettext's _ macro as format string
         # not being a string literal and produces a lot of warnings - which

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -59,6 +59,12 @@ do_debug_gdb_build_cross()
         cross_extra_config+=("--disable-sim")
     fi
 
+    if [ "${CT_GDB_CROSS_LZMA}" = "y" ]; then
+        cross_extra_config+=("--with-lzma")
+    else
+        cross_extra_config+=("--without-lzma")
+    fi
+
     if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
         # clang detects the line from gettext's _ macro as format string
         # not being a string literal and produces a lot of warnings - which


### PR DESCRIPTION
cross-gdb: Add LZMA and Guile scripting support configuration