### PR TITLE
Strip picolibc and newlib-nano libraries

### DIFF
--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -166,6 +166,20 @@ EOF
     CT_EndStep
 
     do_cc_libstdcxx_picolibc
+
+    if [ "${CT_STRIP_TARGET_TOOLCHAIN_LIBRARIES}" = "y" ]; then
+
+	CT_DoStep INFO "Stripping Picolibc library"
+
+	CT_Pushd "${CT_PREFIX_DIR}"
+
+	strip_target_lib "${CT_PREFIX_DIR}/picolibc/${CT_TARGET}/lib" "*.a"
+	strip_target_lib "${CT_PREFIX_DIR}/picolibc/${CT_TARGET}/lib" "*.o"
+
+	CT_Popd
+
+	CT_EndStep
+    fi
 }
 
 fi


### PR DESCRIPTION
As these are not installed in the usual lib directory,
the library stripping option doesn't catch them. Add explicit
steps in each of these companion library build scripts to
perform this task.

Signed-off-by: Keith Packard <keithp@keithp.com>