### PR TITLE
picolibc: Add 'objcopy' to list of target-specific binaries

### DIFF
--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -132,6 +132,7 @@ c = '${CT_TARGET}-gcc'
 ar = '${CT_TARGET}-ar'
 as = '${CT_TARGET}-as'
 strip = '${CT_TARGET}-strip'
+objcopy = '${CT_TARGET}-objcopy'
 
 [host_machine]
 system = '${CT_TARGET_VENDOR}'


### PR DESCRIPTION
The x86_64 build uses objcopy, and if that is run in a cross-build environment, the native version will not work. Use the target-specific name instead.

Signed-off-by: Keith Packard <keithp@keithp.com>