### PR TITLE
picolibc: Don't disable wchar_t in libstdc++ for picolibc >= 1.8.1

### DIFF
--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -40,7 +40,9 @@ do_cc_libstdcxx_picolibc()
         final_opts+=( "lang_list=c,c++" )
         final_opts+=( "build_step=libstdcxx" )
         final_opts+=( "extra_config+=('--enable-stdio=stdio_pure')" )
-        final_opts+=( "extra_config+=('--disable-wchar_t')" )
+        if [ "${CT_PICOLIBC_older_than_1_8}" = "y" ]; then
+            final_opts+=( "extra_config+=('--disable-wchar_t')" )
+        fi
         if [ "${CT_LIBC_PICOLIBC_ENABLE_TARGET_OPTSPACE}" = "y" ]; then
             final_opts+=( "enable_optspace=yes" )
         fi


### PR DESCRIPTION
Picolibc 1.8.1 includes stdio support for wchar_t, so we can now include wchar_t support in libstdc++.