### PR TITLE
picolibc: Disable exceptions for picolibc libstdc++

### DIFF
--- a/config/comp_libs/picolibc.in
+++ b/config/comp_libs/picolibc.in
@@ -20,6 +20,14 @@ config LIBC_PICOLIBC_GCC_LIBSTDCXX
       picolibc. This version is linked when "--specs=picolibcpp.specs"
       is specified.
 
+config LIBC_PICOLIBC_GCC_LIBSTDCXX_TARGET_CXXFLAGS
+    string
+    prompt "Target CXXFLAGS for libstdc++ picolibc variant"
+    default "-fno-exceptions"
+    help
+      Used to add extra CXXFLAGS when compiling the target libstdc++
+      picolibc library (e.g. -fno-exceptions).
+
 config LIBC_PICOLIBC_CXA_ATEXIT
     def_bool y
     select LIBC_PROVIDES_CXA_ATEXIT

--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -44,6 +44,9 @@ do_cc_libstdcxx_picolibc()
         if [ "${CT_LIBC_PICOLIBC_ENABLE_TARGET_OPTSPACE}" = "y" ]; then
             final_opts+=( "enable_optspace=yes" )
         fi
+        if [ -n "${CT_LIBC_PICOLIBC_GCC_LIBSTDCXX_TARGET_CXXFLAGS}" ]; then
+            final_opts+=( "extra_cxxflags_for_target=${CT_LIBC_PICOLIBC_GCC_LIBSTDCXX_TARGET_CXXFLAGS}" )
+        fi
 
         if [ "${CT_BARE_METAL}" = "y" ]; then
             final_opts+=( "mode=baremetal" )


### PR DESCRIPTION
Add `CT_LIBC_PICOLIBC_GCC_LIBSTDCXX_TARGET_CXXFLAGS` config option and set it by default to `-fno-exceptions`.