### PR TITLE
gcc: Fix the option name for controlling libstdc++ I/O calls

### DIFF
--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -39,7 +39,7 @@ do_cc_libstdcxx_picolibc()
         final_opts+=( "ldflags=${CT_LDFLAGS_FOR_HOST}" )
         final_opts+=( "lang_list=c,c++" )
         final_opts+=( "build_step=libstdcxx" )
-        final_opts+=( "extra_config+=('--enable-stdio=stdio_pure')" )
+        final_opts+=( "extra_config+=('--enable-cstdio=stdio_pure')" )
         if [ "${CT_PICOLIBC_older_than_1_8}" = "y" ]; then
             final_opts+=( "extra_config+=('--disable-wchar_t')" )
         fi


### PR DESCRIPTION
The upstream option name for selecting how libstdc++ performs I/O is '--enable-cstdio', not '--enable-stdio'.