### PR TITLE
gcc: Support --enable-multilib-space with CT_MULTILIB_SPACE

### DIFF
--- a/config/target.in
+++ b/config/target.in
@@ -62,10 +62,24 @@ config MULTILIB
       NOTE: The multilib feature in crosstool-NG is not well-tested.
             Use at your own risk, and report success and/or failure.
 
+config MULTILIB_SPACE
+    bool
+    prompt "Build both speed and space optimized multilibs"
+    help
+      If you say 'y' here, then the toolchain will contain two versions
+      of every multilib, one optimized for speed (the default) and another
+      optimized for space. When building with the toolchain, linking with
+      -Os or -Oz will automatically select the space optimized variant.
+
+# either MULTILIB or MULTILIB_SPACE is set
+config MULTILIB_ANY
+     bool
+     default y if MULTILIB || MULTILIB_SPACE
+
 config DEMULTILIB
     bool "Attempt to combine libraries into a single directory"
-    default y if !MULTILIB
-    depends on !MULTILIB || EXPERIMENTAL
+    default y if !MULTILIB_ANY
+    depends on !MULTILIB_ANY || EXPERIMENTAL
     help
       Normally, Crosstool-NG installs the libraries into the directories
       as the configure for these libraries determines appropriate. For

--- a/scripts/build/binutils/binutils.sh
+++ b/scripts/build/binutils/binutils.sh
@@ -346,7 +346,7 @@ do_binutils_for_target() {
 
         [ -n "${CT_PKGVERSION}" ] && extra_config+=("--with-pkgversion=${CT_PKGVERSION}")
         [ -n "${CT_TOOLCHAIN_BUGURL}" ] && extra_config+=("--with-bugurl=${CT_TOOLCHAIN_BUGURL}")
-        if [ "${CT_MULTILIB}" = "y" ]; then
+        if [ "${CT_MULTILIB_ANY}" = "y" ]; then
             extra_config+=("--enable-multilib")
         else
             extra_config+=("--disable-multilib")

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -584,6 +584,9 @@ do_gcc_core_backend() {
             extra_config+=("--with-multilib-generator=${CT_CC_GCC_MULTILIB_GENERATOR}")
         fi
     fi
+    if [ "${CT_MULTILIB_SPACE}" = "y" ]; then
+	extra_config+=("--enable-multilib-space")
+    fi
 
     CT_DoLog DEBUG "Extra config passed: '${extra_config[*]}'"
 

--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -20,7 +20,7 @@ do_picolibc_common_install() {
     CT_DoLog EXTRA "Configuring C library"
 
     # Multilib is the default, so if it is not enabled, disable it.
-    if [ "${CT_MULTILIB}" != "y" ]; then
+    if [ "${CT_MULTILIB_ANY}" != "y" ]; then
         picolibc_opts+=("-Dmultilib=false")
     fi
 
@@ -65,6 +65,17 @@ NANO_MALLOC:newlib-nano-malloc
 
     [ "${CT_LIBC_PICOLIBC_LTO}" = "y" ] && \
         CT_LIBC_PICOLIBC_TARGET_CFLAGS="${CT_LIBC_PICOLIBC_TARGET_CFLAGS} -flto"
+
+    # Build picolibc in release mode when doing multilib-space mode as
+    # we want the default to be release, not minsize; you'll still get
+    # the -Os version if you link with -Os on the command line due to
+    # multilib
+
+    if [ "${CT_LIBC_PICOLIBC_ENABLE_TARGET_OPTSPACE}" = "y" -a "${CT_MULTILIB_SPACE}" != "y" ]; then
+        buildtype="minsize"
+    else
+        buildtype="release"
+    fi
 
     cflags_for_target="${CT_ALL_TARGET_CFLAGS} ${CT_LIBC_PICOLIBC_TARGET_CFLAGS}"
 
@@ -113,9 +124,10 @@ EOF
     fi
 
     CT_DoExecLog CFG                                               \
-    meson                                                          \
+    meson setup                                                    \
         --cross-file picolibc-cross.txt                            \
         --prefix="${picolibc_sysroot_dir}"                         \
+	--buildtype="${buildtype}"                                 \
         -Dincludedir=include                                       \
         -Dlibdir="${picolibc_lib_dir}"                             \
         -Dspecsdir="${CT_SYSROOT_DIR}/lib"                         \

--- a/scripts/build/companion_libs/350-newlib_nano.sh
+++ b/scripts/build/companion_libs/350-newlib_nano.sh
@@ -108,7 +108,7 @@ do_newlib_nano_for_target() {
     CT_DoLog EXTRA "Configuring Newlib Nano library"
 
     # Multilib is the default, so if it is not enabled, disable it.
-    if [ "${CT_MULTILIB}" != "y" ]; then
+    if [ "${CT_MULTILIB_ANY}" != "y" ]; then
         newlib_nano_opts+=("-Dmultilib=false")
     fi
 

--- a/scripts/build/libc/newlib.sh
+++ b/scripts/build/libc/newlib.sh
@@ -29,7 +29,7 @@ newlib_main()
     CT_DoLog EXTRA "Configuring C library"
 
     # Multilib is the default, so if it is not enabled, disable it.
-    if [ "${CT_MULTILIB}" != "y" ]; then
+    if [ "${CT_MULTILIB_ANY}" != "y" ]; then
         newlib_opts+=("--disable-multilib")
     fi
 


### PR DESCRIPTION
When CT_MULTILIB_SPACE is selected, build gcc with the --enable-multilib-space flag.