### PR TITLE
Add back missing patches for 1.27.0

### DIFF
--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -26,6 +26,15 @@ config GDB_CROSS_STATIC
       That way, you can share the cross-gdb without installing a toolchain
       on every machine that will be used to debug target programs.
 
+config GDB_CROSS_STATIC_LIBSTDCXX
+    bool
+    prompt "Link against static libstdc+++"
+    depends on !GDB_CROSS_STATIC
+    default y
+    help
+      Say 'y' if you do not want gdb to require libstdc++ and libgcc shared
+      libraries on the host.
+
 config GDB_CROSS_SIM
     bool
     prompt "Enable 'sim'"

--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -96,6 +96,16 @@ config GDB_CROSS_LZMA
       Note that crosstool-ng does not build liblzma for the host and you are
       responsible for providing this library on the build system.
 
+config GDB_CROSS_GUILE
+    bool
+    prompt "Build GDB with GNU Guile scripting support"
+    help
+      Build GDB with libguile, a library implementing the GNU Guile scripting
+      feature.
+
+      Note that crosstool-ng does not build libguile for the host and you are
+      responsible for providing this library on the build system.
+
 config GDB_CROSS_EXTRA_CONFIG_ARRAY
     string
     prompt "Cross-gdb extra config"

--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -85,6 +85,17 @@ config GDB_CROSS_PYTHON_BINARY
       help message in gdb's configure script for the --with-python option
       for further guidance.
 
+config GDB_CROSS_LZMA
+    bool
+    prompt "Build GDB with LZMA"
+    help
+      Build GDB with liblzma, a compression library supporting the LZMA
+      algorithm. LZMA is used by the GDB's "mini debuginfo" feature, which is
+      only useful on the platforms using the ELF object file format.
+
+      Note that crosstool-ng does not build liblzma for the host and you are
+      responsible for providing this library on the build system.
+
 config GDB_CROSS_EXTRA_CONFIG_ARRAY
     string
     prompt "Cross-gdb extra config"

--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -58,6 +58,17 @@ config GDB_CROSS_PYTHON
       have been reports of problems when linking gdb to the static
       libpython.a. This should be fixed in gdb >=7.3. YMMV.
 
+config GDB_CROSS_PYTHON_VARIANT
+    bool
+    prompt "Build additional Python-capable gdb variant (gdb-py)"
+    depends on GDB_CROSS_PYTHON
+    help
+      Build an additional gdb variant (gdb-py) that supports Python scripting.
+
+      When this option is enabled, the default gdb variant (gdb) does not link
+      against libpython; instead, an additional Python-capable gdb variant
+      executable (gdb-py) that links against libpython is built.
+
 config GDB_CROSS_PYTHON_BINARY
     string "Python binary to use"
     depends on GDB_CROSS_PYTHON

--- a/config/debug/gdb.in.cross
+++ b/config/debug/gdb.in.cross
@@ -49,17 +49,6 @@ config GDB_CROSS_PYTHON
       have been reports of problems when linking gdb to the static
       libpython.a. This should be fixed in gdb >=7.3. YMMV.
 
-config GDB_CROSS_PYTHON_VARIANT
-    bool
-    prompt "Build additional Python-capable gdb variant (gdb-py)"
-    depends on GDB_CROSS_PYTHON
-    help
-      Build an additional gdb variant (gdb-py) that supports Python scripting.
-
-      When this option is enabled, the default gdb variant (gdb) does not link
-      against libpython; instead, an additional Python-capable gdb variant
-      executable (gdb-py) that links against libpython is built.
-
 config GDB_CROSS_PYTHON_BINARY
     string "Python binary to use"
     depends on GDB_CROSS_PYTHON

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -65,6 +65,12 @@ do_debug_gdb_build_cross()
         cross_extra_config+=("--without-lzma")
     fi
 
+    if [ "${CT_GDB_CROSS_GUILE}" = "y" ]; then
+        cross_extra_config+=("--with-guile")
+    else
+        cross_extra_config+=("--without-guile")
+    fi
+
     if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
         # clang detects the line from gettext's _ macro as format string
         # not being a string literal and produces a lot of warnings - which

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -59,6 +59,12 @@ do_debug_gdb_build_cross()
         cross_extra_config+=("--disable-sim")
     fi
 
+    if [ "${CT_GDB_CROSS_LZMA}" = "y" ]; then
+        cross_extra_config+=("--with-lzma")
+    else
+        cross_extra_config+=("--without-lzma")
+    fi
+
     if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
         # clang detects the line from gettext's _ macro as format string
         # not being a string literal and produces a lot of warnings - which

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -83,7 +83,7 @@ do_debug_gdb_build()
             ldflags="${CT_LDFLAGS_FOR_HOST}" \
             prefix="${CT_PREFIX_DIR}" \
             static="${CT_GDB_CROSS_STATIC}" \
-            static_libstdcxx="${CT_GDB_CROSS_STATIC}" \
+            static_libstdcxx="${CT_GDB_CROSS_STATIC_LIBSTDCXX}" \
             --with-sysroot="${CT_SYSROOT_DIR}"          \
             "${cross_extra_config[@]}"
 
@@ -296,8 +296,18 @@ do_gdb_backend()
         extra_config+=("--disable-source-highlight")
     fi
     if [ "${static_libstdcxx}" = "y" ]; then
-        ldflags+=" -static-libgcc"
-        ldflags+=" -static-libstdc++"
+        case "$CT_HOST" in
+            *darwin*)
+                # macOS builds with clang and provides a well known execution
+                # environment, so there is little point in static linking the
+                # C++ runtime library -- ignore this option for now.
+                ;;
+            *)
+                ldflags+=" -static-libgcc"
+                ldflags+=" -static-libstdc++"
+                ;;
+        esac
+
         # libsource-highlight is a dynamic library that uses exception
         # exceptions are handled by libstdc++
         # this combination is very buggy, so configure don't use it and abort

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -12,43 +12,25 @@ do_debug_gdb_extract()
 
 do_debug_gdb_build_cross()
 {
-    local progprefix progsuffix usepython
     local gcc_version p _p
     local -a cross_extra_config
 
-    for arg in "$@"; do
-        case "$arg" in
-            *)
-                eval "${arg// /\\ }"
-                ;;
-        esac
-    done
-
-    CT_DoStep INFO "Installing cross-${progprefix}gdb${progsuffix}"
-    CT_mkdir_pushd "${CT_BUILD_DIR}/build-${progprefix}gdb${progsuffix}-cross"
+    CT_DoStep INFO "Installing cross-gdb"
+    CT_mkdir_pushd "${CT_BUILD_DIR}/build-gdb-cross"
 
     cross_extra_config=( "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}" )
-
-    if [ -n "${progprefix}" ]; then
-        cross_extra_config+=("--program-prefix=${progprefix}")
-    fi
-
-    if [ -n "${progsuffix}" ]; then
-        cross_extra_config+=("--program-suffix=${progsuffix}")
-    fi
-
-    if [ "${usepython}" = "y" ]; then
-        if [ -z "${CT_GDB_CROSS_PYTHON_BINARY}" ]; then
-            if [ "${CT_CANADIAN}" = "y" -o "${CT_CROSS_NATIVE}" = "y" ]; then
-                CT_Abort "For canadian build, Python wrapper runnable on the build machine must be provided. Set CT_GDB_CROSS_PYTHON_BINARY."
-            elif [ "${CT_CONFIGURE_has_python}" = "y" ]; then
-                cross_extra_config+=("--with-python=${python}")
-            else
-                CT_Abort "Python support requested in GDB, but Python not found. Set CT_GDB_CROSS_PYTHON_BINARY."
-            fi
-        else
-            cross_extra_config+=("--with-python=${CT_GDB_CROSS_PYTHON_BINARY}")
-        fi
+    if [ "${CT_GDB_CROSS_PYTHON}" = "y" ]; then
+	if [ -z "${CT_GDB_CROSS_PYTHON_BINARY}" ]; then
+	    if [ "${CT_CANADIAN}" = "y" -o "${CT_CROSS_NATIVE}" = "y" ]; then
+		CT_Abort "For canadian build, Python wrapper runnable on the build machine must be provided. Set CT_GDB_CROSS_PYTHON_BINARY."
+	    elif [ "${CT_CONFIGURE_has_python}" = "y" ]; then
+		cross_extra_config+=("--with-python=${python}")
+	    else
+		CT_Abort "Python support requested in GDB, but Python not found. Set CT_GDB_CROSS_PYTHON_BINARY."
+	    fi
+	else
+	    cross_extra_config+=("--with-python=${CT_GDB_CROSS_PYTHON_BINARY}")
+	fi
     else
 	cross_extra_config+=("--with-python=no")
     fi
@@ -133,18 +115,7 @@ do_debug_gdb_build_cross()
 do_debug_gdb_build()
 {
     if [ "${CT_GDB_CROSS}" = "y" ]; then
-        if [ "${CT_GDB_CROSS_PYTHON_VARIANT}" = "y" ]; then
-            do_debug_gdb_build_cross \
-                usepython=n
-
-            do_debug_gdb_build_cross \
-                usepython=y \
-                progprefix="${CT_TARGET}-" \
-                progsuffix="-py"
-        else
-            do_debug_gdb_build_cross \
-                usepython="${CT_GDB_CROSS_PYTHON}"
-        fi
+        do_debug_gdb_build_cross
     fi
 
     if [ "${CT_GDB_NATIVE}" = "y" ]; then

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -10,112 +10,107 @@ do_debug_gdb_extract()
     CT_ExtractPatch GDB
 }
 
-do_debug_gdb_build_cross()
-{
-    local gcc_version p _p
-    local -a cross_extra_config
-
-    CT_DoStep INFO "Installing cross-gdb"
-    CT_mkdir_pushd "${CT_BUILD_DIR}/build-gdb-cross"
-
-    cross_extra_config=( "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}" )
-    if [ "${CT_GDB_CROSS_PYTHON}" = "y" ]; then
-	if [ -z "${CT_GDB_CROSS_PYTHON_BINARY}" ]; then
-	    if [ "${CT_CANADIAN}" = "y" -o "${CT_CROSS_NATIVE}" = "y" ]; then
-		CT_Abort "For canadian build, Python wrapper runnable on the build machine must be provided. Set CT_GDB_CROSS_PYTHON_BINARY."
-	    elif [ "${CT_CONFIGURE_has_python}" = "y" ]; then
-		cross_extra_config+=("--with-python=${python}")
-	    else
-		CT_Abort "Python support requested in GDB, but Python not found. Set CT_GDB_CROSS_PYTHON_BINARY."
-	    fi
-	else
-	    cross_extra_config+=("--with-python=${CT_GDB_CROSS_PYTHON_BINARY}")
-	fi
-    else
-	cross_extra_config+=("--with-python=no")
-    fi
-
-    if [ "${CT_GDB_CROSS_SIM}" = "y" ]; then
-	cross_extra_config+=("--enable-sim")
-    else
-	cross_extra_config+=("--disable-sim")
-    fi
-
-    if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
-	# clang detects the line from gettext's _ macro as format string
-	# not being a string literal and produces a lot of warnings - which
-	# ct-ng's logger faithfully relays to user if this happens in the
-	# error() function. Suppress them.
-	cross_extra_config+=("--enable-build-warnings=,-Wno-format-nonliteral,-Wno-format-security")
-    fi
-
-    # Target libexpat resides in sysroot and does not have
-    # any dependencies, so just passing '-lexpat' to gcc is enough.
-    #
-    # By default gdb configure looks for expat in '$prefix/lib'
-    # directory. In our case '$prefix/lib' resolves to '/usr/lib'
-    # where libexpat for build platform lives, which is
-    # unacceptable for cross-compiling.
-    #
-    # To prevent this '--without-libexpat-prefix' flag must be passed.
-    # Thus configure falls back to '-lexpat', which is exactly what we want.
-    #
-    # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
-    # It conflicts with a static build: GDB's configure script will find the shared
-    # version of expat and will attempt to link that, despite the -static flag.
-    # The link will fail, and configure will abort with "expat missing or unusable"
-    # message.
-    cross_extra_config+=("--with-expat")
-    cross_extra_config+=("--without-libexpat-prefix")
-
-    # ct-ng always builds ncurses in cross mode as a static library.
-    # Starting from the patchset 20200718 ncurses defines a special macro
-    # NCURSES_STATIC for a static library. This is critical for mingw host
-    # platform.
-    #
-    # The problem is that the macro must be defined in a user program too,
-    # not just in ncurses. It won't hurt if we define it here.
-    do_gdb_backend \
-	buildtype=cross \
-	host="${CT_HOST}" \
-	cflags="${CT_CFLAGS_FOR_HOST} -DNCURSES_STATIC" \
-	ldflags="${CT_LDFLAGS_FOR_HOST}" \
-	prefix="${CT_PREFIX_DIR}" \
-	static="${CT_GDB_CROSS_STATIC}" \
-	static_libstdcxx="${CT_GDB_CROSS_STATIC}" \
-	--with-sysroot="${CT_SYSROOT_DIR}"          \
-	"${cross_extra_config[@]}"
-
-    if [ "${CT_BUILD_MANUALS}" = "y" ]; then
-	CT_DoLog EXTRA "Building and installing the cross-GDB manuals"
-	CT_DoExecLog ALL make ${CT_JOBSFLAGS} pdf html
-	CT_DoExecLog ALL make install-{pdf,html}-gdb
-    fi
-
-    CT_DoLog EXTRA "Installing '.gdbinit' template"
-    # See in scripts/build/internals.sh for why we do this
-    # TBD GCC 3.x and older not supported
-    if [ -f "${CT_SRC_DIR}/gcc/gcc/BASE-VER" ]; then
-	gcc_version=$(cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER")
-    else
-	gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
-			   "${CT_SRC_DIR}/gcc/gcc/version.c"   \
-		     )
-    fi
-    sed -r                                                  \
-	   -e "s:@@PREFIX@@:${CT_PREFIX_DIR}:;"             \
-	   -e "s:@@VERSION@@:${gcc_version}:;"              \
-	   "${CT_LIB_DIR}/scripts/build/debug/gdbinit.in"   \
-	   >"${CT_PREFIX_DIR}/share/gdb/gdbinit"
-
-    CT_Popd
-    CT_EndStep
-}
-
 do_debug_gdb_build()
 {
     if [ "${CT_GDB_CROSS}" = "y" ]; then
-        do_debug_gdb_build_cross
+        local gcc_version p _p
+        local -a cross_extra_config
+
+        CT_DoStep INFO "Installing cross-gdb"
+        CT_mkdir_pushd "${CT_BUILD_DIR}/build-gdb-cross"
+
+        cross_extra_config=( "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}" )
+        if [ "${CT_GDB_CROSS_PYTHON}" = "y" ]; then
+            if [ -z "${CT_GDB_CROSS_PYTHON_BINARY}" ]; then
+                if [ "${CT_CANADIAN}" = "y" -o "${CT_CROSS_NATIVE}" = "y" ]; then
+                    CT_Abort "For canadian build, Python wrapper runnable on the build machine must be provided. Set CT_GDB_CROSS_PYTHON_BINARY."
+                elif [ "${CT_CONFIGURE_has_python}" = "y" ]; then
+                    cross_extra_config+=("--with-python=${python}")
+                else
+                    CT_Abort "Python support requested in GDB, but Python not found. Set CT_GDB_CROSS_PYTHON_BINARY."
+                fi
+            else
+                cross_extra_config+=("--with-python=${CT_GDB_CROSS_PYTHON_BINARY}")
+            fi
+        else
+            cross_extra_config+=("--with-python=no")
+        fi
+
+        if [ "${CT_GDB_CROSS_SIM}" = "y" ]; then
+            cross_extra_config+=("--enable-sim")
+        else
+            cross_extra_config+=("--disable-sim")
+        fi
+
+        if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
+            # clang detects the line from gettext's _ macro as format string
+            # not being a string literal and produces a lot of warnings - which
+            # ct-ng's logger faithfully relays to user if this happens in the
+            # error() function. Suppress them.
+            cross_extra_config+=("--enable-build-warnings=,-Wno-format-nonliteral,-Wno-format-security")
+        fi
+
+        # Target libexpat resides in sysroot and does not have
+        # any dependencies, so just passing '-lexpat' to gcc is enough.
+        #
+        # By default gdb configure looks for expat in '$prefix/lib'
+        # directory. In our case '$prefix/lib' resolves to '/usr/lib'
+        # where libexpat for build platform lives, which is
+        # unacceptable for cross-compiling.
+        #
+        # To prevent this '--without-libexpat-prefix' flag must be passed.
+        # Thus configure falls back to '-lexpat', which is exactly what we want.
+        #
+        # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
+        # It conflicts with a static build: GDB's configure script will find the shared
+        # version of expat and will attempt to link that, despite the -static flag.
+        # The link will fail, and configure will abort with "expat missing or unusable"
+        # message.
+        cross_extra_config+=("--with-expat")
+        cross_extra_config+=("--without-libexpat-prefix")
+
+        # ct-ng always builds ncurses in cross mode as a static library.
+        # Starting from the patchset 20200718 ncurses defines a special macro
+        # NCURSES_STATIC for a static library. This is critical for mingw host
+        # platform.
+        #
+        # The problem is that the macro must be defined in a user program too,
+        # not just in ncurses. It won't hurt if we define it here.
+        do_gdb_backend \
+            buildtype=cross \
+            host="${CT_HOST}" \
+            cflags="${CT_CFLAGS_FOR_HOST} -DNCURSES_STATIC" \
+            ldflags="${CT_LDFLAGS_FOR_HOST}" \
+            prefix="${CT_PREFIX_DIR}" \
+            static="${CT_GDB_CROSS_STATIC}" \
+            static_libstdcxx="${CT_GDB_CROSS_STATIC}" \
+            --with-sysroot="${CT_SYSROOT_DIR}"          \
+            "${cross_extra_config[@]}"
+
+        if [ "${CT_BUILD_MANUALS}" = "y" ]; then
+            CT_DoLog EXTRA "Building and installing the cross-GDB manuals"
+            CT_DoExecLog ALL make ${CT_JOBSFLAGS} pdf html
+            CT_DoExecLog ALL make install-{pdf,html}-gdb
+        fi
+
+        CT_DoLog EXTRA "Installing '.gdbinit' template"
+        # See in scripts/build/internals.sh for why we do this
+        # TBD GCC 3.x and older not supported
+        if [ -f "${CT_SRC_DIR}/gcc/gcc/BASE-VER" ]; then
+            gcc_version=$(cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER")
+        else
+            gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
+                               "${CT_SRC_DIR}/gcc/gcc/version.c"   \
+                         )
+        fi
+        sed -r                                                  \
+               -e "s:@@PREFIX@@:${CT_PREFIX_DIR}:;"             \
+               -e "s:@@VERSION@@:${gcc_version}:;"              \
+               "${CT_LIB_DIR}/scripts/build/debug/gdbinit.in"   \
+               >"${CT_PREFIX_DIR}/share/gdb/gdbinit"
+
+        CT_Popd
+        CT_EndStep
     fi
 
     if [ "${CT_GDB_NATIVE}" = "y" ]; then

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -12,14 +12,32 @@ do_debug_gdb_extract()
 
 do_debug_gdb_build_cross()
 {
+    local progprefix progsuffix usepython
     local gcc_version p _p
     local -a cross_extra_config
 
-    CT_DoStep INFO "Installing cross-gdb"
-    CT_mkdir_pushd "${CT_BUILD_DIR}/build-gdb-cross"
+    for arg in "$@"; do
+        case "$arg" in
+            *)
+                eval "${arg// /\\ }"
+                ;;
+        esac
+    done
+
+    CT_DoStep INFO "Installing cross-${progprefix}gdb${progsuffix}"
+    CT_mkdir_pushd "${CT_BUILD_DIR}/build-${progprefix}gdb${progsuffix}-cross"
 
     cross_extra_config=( "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}" )
-    if [ "${CT_GDB_CROSS_PYTHON}" = "y" ]; then
+
+    if [ -n "${progprefix}" ]; then
+        cross_extra_config+=("--program-prefix=${progprefix}")
+    fi
+
+    if [ -n "${progsuffix}" ]; then
+        cross_extra_config+=("--program-suffix=${progsuffix}")
+    fi
+
+    if [ "${usepython}" = "y" ]; then
         if [ -z "${CT_GDB_CROSS_PYTHON_BINARY}" ]; then
             if [ "${CT_CANADIAN}" = "y" -o "${CT_CROSS_NATIVE}" = "y" ]; then
                 CT_Abort "For canadian build, Python wrapper runnable on the build machine must be provided. Set CT_GDB_CROSS_PYTHON_BINARY."
@@ -115,7 +133,18 @@ do_debug_gdb_build_cross()
 do_debug_gdb_build()
 {
     if [ "${CT_GDB_CROSS}" = "y" ]; then
-        do_debug_gdb_build_cross
+        if [ "${CT_GDB_CROSS_PYTHON_VARIANT}" = "y" ]; then
+            do_debug_gdb_build_cross \
+                usepython=n
+
+            do_debug_gdb_build_cross \
+                usepython=y \
+                progprefix="${CT_TARGET}-" \
+                progsuffix="-py"
+        else
+            do_debug_gdb_build_cross \
+                usepython="${CT_GDB_CROSS_PYTHON}"
+        fi
     fi
 
     if [ "${CT_GDB_NATIVE}" = "y" ]; then

--- a/scripts/build/debug/300-gdb.sh
+++ b/scripts/build/debug/300-gdb.sh
@@ -10,107 +10,112 @@ do_debug_gdb_extract()
     CT_ExtractPatch GDB
 }
 
+do_debug_gdb_build_cross()
+{
+    local gcc_version p _p
+    local -a cross_extra_config
+
+    CT_DoStep INFO "Installing cross-gdb"
+    CT_mkdir_pushd "${CT_BUILD_DIR}/build-gdb-cross"
+
+    cross_extra_config=( "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}" )
+    if [ "${CT_GDB_CROSS_PYTHON}" = "y" ]; then
+        if [ -z "${CT_GDB_CROSS_PYTHON_BINARY}" ]; then
+            if [ "${CT_CANADIAN}" = "y" -o "${CT_CROSS_NATIVE}" = "y" ]; then
+                CT_Abort "For canadian build, Python wrapper runnable on the build machine must be provided. Set CT_GDB_CROSS_PYTHON_BINARY."
+            elif [ "${CT_CONFIGURE_has_python}" = "y" ]; then
+                cross_extra_config+=("--with-python=${python}")
+            else
+                CT_Abort "Python support requested in GDB, but Python not found. Set CT_GDB_CROSS_PYTHON_BINARY."
+            fi
+        else
+            cross_extra_config+=("--with-python=${CT_GDB_CROSS_PYTHON_BINARY}")
+        fi
+    else
+        cross_extra_config+=("--with-python=no")
+    fi
+
+    if [ "${CT_GDB_CROSS_SIM}" = "y" ]; then
+        cross_extra_config+=("--enable-sim")
+    else
+        cross_extra_config+=("--disable-sim")
+    fi
+
+    if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
+        # clang detects the line from gettext's _ macro as format string
+        # not being a string literal and produces a lot of warnings - which
+        # ct-ng's logger faithfully relays to user if this happens in the
+        # error() function. Suppress them.
+        cross_extra_config+=("--enable-build-warnings=,-Wno-format-nonliteral,-Wno-format-security")
+    fi
+
+    # Target libexpat resides in sysroot and does not have
+    # any dependencies, so just passing '-lexpat' to gcc is enough.
+    #
+    # By default gdb configure looks for expat in '$prefix/lib'
+    # directory. In our case '$prefix/lib' resolves to '/usr/lib'
+    # where libexpat for build platform lives, which is
+    # unacceptable for cross-compiling.
+    #
+    # To prevent this '--without-libexpat-prefix' flag must be passed.
+    # Thus configure falls back to '-lexpat', which is exactly what we want.
+    #
+    # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
+    # It conflicts with a static build: GDB's configure script will find the shared
+    # version of expat and will attempt to link that, despite the -static flag.
+    # The link will fail, and configure will abort with "expat missing or unusable"
+    # message.
+    cross_extra_config+=("--with-expat")
+    cross_extra_config+=("--without-libexpat-prefix")
+
+    # ct-ng always builds ncurses in cross mode as a static library.
+    # Starting from the patchset 20200718 ncurses defines a special macro
+    # NCURSES_STATIC for a static library. This is critical for mingw host
+    # platform.
+    #
+    # The problem is that the macro must be defined in a user program too,
+    # not just in ncurses. It won't hurt if we define it here.
+    do_gdb_backend \
+        buildtype=cross \
+        host="${CT_HOST}" \
+        cflags="${CT_CFLAGS_FOR_HOST} -DNCURSES_STATIC" \
+        ldflags="${CT_LDFLAGS_FOR_HOST}" \
+        prefix="${CT_PREFIX_DIR}" \
+        static="${CT_GDB_CROSS_STATIC}" \
+        static_libstdcxx="${CT_GDB_CROSS_STATIC_LIBSTDCXX}" \
+        --with-sysroot="${CT_SYSROOT_DIR}"          \
+        "${cross_extra_config[@]}"
+
+    if [ "${CT_BUILD_MANUALS}" = "y" ]; then
+        CT_DoLog EXTRA "Building and installing the cross-GDB manuals"
+        CT_DoExecLog ALL make ${CT_JOBSFLAGS} pdf html
+        CT_DoExecLog ALL make install-{pdf,html}-gdb
+    fi
+
+    CT_DoLog EXTRA "Installing '.gdbinit' template"
+    # See in scripts/build/internals.sh for why we do this
+    # TBD GCC 3.x and older not supported
+    if [ -f "${CT_SRC_DIR}/gcc/gcc/BASE-VER" ]; then
+        gcc_version=$(cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER")
+    else
+        gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
+                           "${CT_SRC_DIR}/gcc/gcc/version.c"   \
+                     )
+    fi
+    sed -r                                                  \
+           -e "s:@@PREFIX@@:${CT_PREFIX_DIR}:;"             \
+           -e "s:@@VERSION@@:${gcc_version}:;"              \
+           "${CT_LIB_DIR}/scripts/build/debug/gdbinit.in"   \
+           >"${CT_PREFIX_DIR}/share/gdb/gdbinit"
+
+    CT_Popd
+    CT_EndStep
+}
+
 do_debug_gdb_build()
 {
     if [ "${CT_GDB_CROSS}" = "y" ]; then
-        local gcc_version p _p
-        local -a cross_extra_config
-
-        CT_DoStep INFO "Installing cross-gdb"
-        CT_mkdir_pushd "${CT_BUILD_DIR}/build-gdb-cross"
-
-        cross_extra_config=( "${CT_GDB_CROSS_EXTRA_CONFIG_ARRAY[@]}" )
-        if [ "${CT_GDB_CROSS_PYTHON}" = "y" ]; then
-            if [ -z "${CT_GDB_CROSS_PYTHON_BINARY}" ]; then
-                if [ "${CT_CANADIAN}" = "y" -o "${CT_CROSS_NATIVE}" = "y" ]; then
-                    CT_Abort "For canadian build, Python wrapper runnable on the build machine must be provided. Set CT_GDB_CROSS_PYTHON_BINARY."
-                elif [ "${CT_CONFIGURE_has_python}" = "y" ]; then
-                    cross_extra_config+=("--with-python=${python}")
-                else
-                    CT_Abort "Python support requested in GDB, but Python not found. Set CT_GDB_CROSS_PYTHON_BINARY."
-                fi
-            else
-                cross_extra_config+=("--with-python=${CT_GDB_CROSS_PYTHON_BINARY}")
-            fi
-        else
-            cross_extra_config+=("--with-python=no")
-        fi
-
-        if [ "${CT_GDB_CROSS_SIM}" = "y" ]; then
-            cross_extra_config+=("--enable-sim")
-        else
-            cross_extra_config+=("--disable-sim")
-        fi
-
-        if ${CT_HOST}-gcc --version 2>&1 | grep clang; then
-            # clang detects the line from gettext's _ macro as format string
-            # not being a string literal and produces a lot of warnings - which
-            # ct-ng's logger faithfully relays to user if this happens in the
-            # error() function. Suppress them.
-            cross_extra_config+=("--enable-build-warnings=,-Wno-format-nonliteral,-Wno-format-security")
-        fi
-
-        # Target libexpat resides in sysroot and does not have
-        # any dependencies, so just passing '-lexpat' to gcc is enough.
-        #
-        # By default gdb configure looks for expat in '$prefix/lib'
-        # directory. In our case '$prefix/lib' resolves to '/usr/lib'
-        # where libexpat for build platform lives, which is
-        # unacceptable for cross-compiling.
-        #
-        # To prevent this '--without-libexpat-prefix' flag must be passed.
-        # Thus configure falls back to '-lexpat', which is exactly what we want.
-        #
-        # NOTE: DO NOT USE --with-libexpat-prefix (until GDB configure is smarter)!!!
-        # It conflicts with a static build: GDB's configure script will find the shared
-        # version of expat and will attempt to link that, despite the -static flag.
-        # The link will fail, and configure will abort with "expat missing or unusable"
-        # message.
-        cross_extra_config+=("--with-expat")
-        cross_extra_config+=("--without-libexpat-prefix")
-
-        # ct-ng always builds ncurses in cross mode as a static library.
-        # Starting from the patchset 20200718 ncurses defines a special macro
-        # NCURSES_STATIC for a static library. This is critical for mingw host
-        # platform.
-        #
-        # The problem is that the macro must be defined in a user program too,
-        # not just in ncurses. It won't hurt if we define it here.
-        do_gdb_backend \
-            buildtype=cross \
-            host="${CT_HOST}" \
-            cflags="${CT_CFLAGS_FOR_HOST} -DNCURSES_STATIC" \
-            ldflags="${CT_LDFLAGS_FOR_HOST}" \
-            prefix="${CT_PREFIX_DIR}" \
-            static="${CT_GDB_CROSS_STATIC}" \
-            static_libstdcxx="${CT_GDB_CROSS_STATIC_LIBSTDCXX}" \
-            --with-sysroot="${CT_SYSROOT_DIR}"          \
-            "${cross_extra_config[@]}"
-
-        if [ "${CT_BUILD_MANUALS}" = "y" ]; then
-            CT_DoLog EXTRA "Building and installing the cross-GDB manuals"
-            CT_DoExecLog ALL make ${CT_JOBSFLAGS} pdf html
-            CT_DoExecLog ALL make install-{pdf,html}-gdb
-        fi
-
-        CT_DoLog EXTRA "Installing '.gdbinit' template"
-        # See in scripts/build/internals.sh for why we do this
-        # TBD GCC 3.x and older not supported
-        if [ -f "${CT_SRC_DIR}/gcc/gcc/BASE-VER" ]; then
-            gcc_version=$(cat "${CT_SRC_DIR}/gcc/gcc/BASE-VER")
-        else
-            gcc_version=$(sed -r -e '/version_string/!d; s/^.+= "([^"]+)".*$/\1/;'   \
-                               "${CT_SRC_DIR}/gcc/gcc/version.c"   \
-                         )
-        fi
-        sed -r                                                  \
-               -e "s:@@PREFIX@@:${CT_PREFIX_DIR}:;"             \
-               -e "s:@@VERSION@@:${gcc_version}:;"              \
-               "${CT_LIB_DIR}/scripts/build/debug/gdbinit.in"   \
-               >"${CT_PREFIX_DIR}/share/gdb/gdbinit"
-
-        CT_Popd
-        CT_EndStep
+        do_debug_gdb_build_cross
     fi
 
     if [ "${CT_GDB_NATIVE}" = "y" ]; then


### PR DESCRIPTION
Add back the patches from `zephyr-crosstool-ng-1.25.0` that were missed while porting to crosstool-ng 1.27.0.

In particular, "gdb: Add CT_GDB_CROSS_STATIC_LIBSTDCXX configuration" is absolutely critical in making the GDB executable self-contained on all host systems and usable on Windows.

Also note that the "gdb: Refactor cross GDB build step" patch initially ported by Anas is reverted because it messed up the file indentation by mixing spaces and tabs -- I have done another iteration of this with the correct indentation in this series.

"cross-gdb: Add LZMA support configuration " and "cross-gdb: Add Guile scripting support configuration" are ported as well because they are still relevant and useful. These will be eventually upstreamed.

---

Fixes https://github.com/zephyrproject-rtos/sdk-ng/issues/972