### PR TITLE
Changes for picolibc 1.8.11 and upstream-style gcc+picolibc support

### DIFF
--- a/config/libc/picolibc.in
+++ b/config/libc/picolibc.in
@@ -102,6 +102,7 @@ config LIBC_PICOLIBC_RETARGETABLE_LOCKING
 config LIBC_PICOLIBC_EXTRA_SECTIONS
     bool
     prompt "Place each function & data element in their own section"
+    default y
     help
         Place each function & data symbol in their own section. This allows
         the linker to garbage collect unused symbols at link time.
@@ -127,7 +128,7 @@ config LIBC_PICOLIBC_LTO
 
 config LIBC_PICOLIBC_NANO_MALLOC
     bool
-    prompt "Enable Nano Malloc"
+    prompt "Enable Nano Malloc [unused]"
     default y
     help
       PICOLIBC has two implementations of malloc family's functions, one in

--- a/scripts/build/cc/gcc.sh
+++ b/scripts/build/cc/gcc.sh
@@ -410,7 +410,7 @@ do_gcc_core_backend() {
     fi
 
     if [ "${CT_LIBC_PICOLIBC}" = "y" ]; then
-        extra_config+=("--with-default-libc=picolibc")
+        extra_config+=("--with-picolibc")
         extra_config+=("--enable-cstdio=stdio_pure")
         if [ "${CT_PICOLIBC_older_than_1_8}" = "y" ]; then
             extra_config+=("--disable-wchar_t")
@@ -1110,9 +1110,11 @@ do_gcc_backend() {
     fi
 
     if [ "${CT_LIBC_PICOLIBC}" = "y" ]; then
-        extra_config+=("--with-default-libc=picolibc")
+        extra_config+=("--with-picolibc")
         extra_config+=("--enable-cstdio=stdio_pure")
-        extra_config+=("--disable-wchar_t")
+        if [ "${CT_PICOLIBC_older_than_1_8}" = "y" ]; then
+            extra_config+=("--disable-wchar_t")
+	fi
     fi
 
     final_LDFLAGS+=("${ldflags}")

--- a/scripts/build/companion_libs/340-picolibc.sh
+++ b/scripts/build/companion_libs/340-picolibc.sh
@@ -24,10 +24,7 @@ do_picolibc_common_install() {
         picolibc_opts+=("-Dmultilib=false")
     fi
 
-    yn_args="IO_C99FMT:io-c99-formats
-IO_LL:io-long-long
-NANO_MALLOC:newlib-nano-malloc
-    "
+    yn_args="IO_C99FMT:io-c99-formats"
 
     for ynarg in $yn_args; do
         var="CT_LIBC_PICOLIBC_${ynarg%:*}"

--- a/scripts/build/libc/picolibc.sh
+++ b/scripts/build/libc/picolibc.sh
@@ -15,9 +15,13 @@ picolibc_extract()
 picolibc_headers()
 {
     CT_DoStep INFO "Installing C library headers"
-    CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/picolibc/newlib/libc/include/." "${CT_HEADERS_DIR}"
-    CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/picolibc/newlib/libc/tinystdio/stdio.h" "${CT_HEADERS_DIR}"
-    CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/picolibc/newlib/libc/tinystdio/stdio-bufio.h" "${CT_HEADERS_DIR}"
+    if [ -d "${CT_SRC_DIR}/picolibc/libc/include" ]; then
+	CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/picolibc/libc/include/." "${CT_HEADERS_DIR}"
+    else	
+	CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/picolibc/newlib/libc/include/." "${CT_HEADERS_DIR}"
+	CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/picolibc/newlib/libc/tinystdio/stdio.h" "${CT_HEADERS_DIR}"
+	CT_DoExecLog ALL cp -a "${CT_SRC_DIR}/picolibc/newlib/libc/tinystdio/stdio-bufio.h" "${CT_HEADERS_DIR}"
+    fi
     CT_DoExecLog ALL touch "${CT_HEADERS_DIR}"/picolibc.h
     CT_EndStep
 }


### PR DESCRIPTION
Picolibc internal directory structure changed, adapt crosstool-ng's code to support either form.
Use the new --with-picolibc flag when building GCC.